### PR TITLE
Add Check for Existing Repair ItemStack Fixes #19

### DIFF
--- a/src/main/java/net/doubledoordev/d3core/util/Materials.java
+++ b/src/main/java/net/doubledoordev/d3core/util/Materials.java
@@ -106,7 +106,7 @@ public class Materials
         for (ToolMaterial material : ToolMaterial.values())
         {
             ItemStack stack = itemStackMap.get(material.name().toLowerCase());
-            if (stack == ItemStack.EMPTY) continue;
+            if (stack == ItemStack.EMPTY || material.getRepairItemStack() != ItemStack.EMPTY) continue;
             material.setRepairItem(stack);
         }
     }


### PR DESCRIPTION
Prevents a Crash when modifying a ToolMaterial that already has an existing Repair ItemStack or Item set.